### PR TITLE
Split listen() and accept() calls

### DIFF
--- a/ServerCommands.cpp
+++ b/ServerCommands.cpp
@@ -66,7 +66,7 @@ void CDir::execute()
 	readPayload();
 
 	/* Extract the filename from the payload */
-	m_directoryName = reinterpret_cast<char*>(m_payload);
+	m_directoryName = reinterpret_cast<char *>(m_payload);
 
 	printf("dir: Listing contents of directory \"%s\"\n", m_directoryName);
 
@@ -205,7 +205,7 @@ void CFileInfo::execute()
 	readPayload();
 
 	/* Extract the filename from the payload */
-	m_fileName = reinterpret_cast<char*>(m_payload);
+	m_fileName = reinterpret_cast<char *>(m_payload);
 
 	printf("fileinfo: Querying information about file \"%s\"\n", m_payload);
 
@@ -231,7 +231,7 @@ void CFileInfo::execute()
 		m_socket->write(&response, sizeof(response));
 		m_socket->write(fileInfo, payloadSize);
 
-		delete[] reinterpret_cast<unsigned char*>(fileInfo);
+		delete[] reinterpret_cast<unsigned char *>(fileInfo);
 	}
 	/* Otherwise just send a response with an empty payload */
 	else


### PR DESCRIPTION
Until now, RADRunner clients would make a single connection to the server and would then exit.  With the reimplementation of the protocol for Brunel, connections can now be made very quickly, one after another, which requires that the same socket be used for multiple connections. Thus, listen() is now only called once, and accept() is called for each connection from a client, to avoid race conditions when connections come from the client very quickly.