### PR TITLE
Bug Fix: CDir was not working properly on Amiga OS

### DIFF
--- a/ClientCommands.cpp
+++ b/ClientCommands.cpp
@@ -50,7 +50,7 @@ void CDir::sendRequest()
 		{
 			name = reinterpret_cast<char *>(payload);
 			payload += strlen(name) + 1;
-			STREAM_INT(size, payload);
+			READ_INT(size, payload);
 			payload += sizeof(size);
 			printf("%s %d\n", name, size);
 

--- a/ServerCommands.cpp
+++ b/ServerCommands.cpp
@@ -10,20 +10,6 @@
 
 #include <sys/wait.h>
 
-#define WRITE_INT(Dest, Value) \
-	*Dest = Value & 0xff; \
-	*(Dest + 1) = (Value >> 8) & 0xff; \
-	*(Dest + 2) = (Value >> 16) & 0xff; \
-	*(Dest + 3) = (Value >> 24) & 0xff
-
-#else /* ! __amigaos__ */
-
-#define WRITE_INT(Dest, Value) \
-	*Dest = (Value >> 24) & 0xff; \
-	*(Dest + 1) = (Value >> 16) & 0xff; \
-	*(Dest + 2) = (Value >> 8) & 0xff; \
-	*(Dest + 3) = Value & 0xff
-
 #endif /* ! __amigaos__ */
 
 /**


### PR DESCRIPTION
Updated integer reading and writing macros to function identially on Amiga OS and other operating systems.