### PR TITLE
Enable compilation on OS4

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 
 CFLAGS = -c -std=gnu++14 -fno-asynchronous-unwind-tables -Wall -Wextra
-IFLAGS = -I../StdFuncs
+IFLAGS = -I../StdFuncs -D__USE_INLINE__
 LFLAGS = -L../StdFuncs/$(OBJ)
 LIBS = -lStdFuncs
 


### PR DESCRIPTION
Added the __USE_INLINE__ preprocessor defintion, to enable compilation on Amiga OS 4.