### PR TITLE
Enable building on OS4 again

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 
 CFLAGS = -c -fno-asynchronous-unwind-tables -std=gnu++14 -Wall -Wextra
-IFLAGS = -I../StdFuncs
+IFLAGS = -I../StdFuncs -D__USE_INLINE__
 LFLAGS = -L../StdFuncs/$(OBJ)
 LIBS = -lStdFuncs
 


### PR DESCRIPTION
Re-adds the __USE_INLINE__ macros, which was erroneously removed from the makefile.