### PR TITLE
Switch Amiga OS3 build to use newlib

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,8 +33,9 @@ ifdef PREFIX
 		LFLAGS += -athread=native
 		OBJ := $(OBJ)_OS4
 	else
-		LFLAGS += -mcrt=clib2
-		LIBS += -lnet
+		IFLAGS += -mcrt=nix20
+		LFLAGS += -mcrt=nix20
+		LIBS += -ldebug -lsocket
 	endif
 endif
 


### PR DESCRIPTION
Exceptions are currently broken on the clib2 support library, and using newlib results in smaller binaries.