### PR TITLE
Update RDir usage for 64 bit file sizes

### DIFF
--- a/ClientCommands.cpp
+++ b/ClientCommands.cpp
@@ -40,8 +40,10 @@ void CDir::sendRequest()
 	if (m_response.m_result == KErrNone)
 	{
 		char *name;
-		uint32_t size;
+		TInt64 size;
 		unsigned char *payload = m_responsePayload, *payloadEnd = m_responsePayload + m_response.m_size;
+
+		printf("payloadSize = %u\n", m_response.m_size);
 
 		/* Iterate through the file information in the payload and display its contents.  Provided the payload */
 		/* is structured correctly, we could just check for it being ended by NULL terminator, but in the */
@@ -49,10 +51,12 @@ void CDir::sendRequest()
 		while (payload < payloadEnd && *payload != '\0')
 		{
 			name = reinterpret_cast<char *>(payload);
+			printf("%s\n", name);
 			payload += strlen(name) + 1;
-			READ_INT(size, payload);
+			READ_INT_64(size, payload);
 			payload += sizeof(size);
-			printf("%s %d\n", name, size);
+			printf("%s %lld\n", name, size);
+			printf("%s %u %x\n", name, (uint32_t) size, (uint32_t) size);
 
 			ASSERTM((payload < payloadEnd), "CDir::sendRequest() => Payload contents do not match its size");
 		}

--- a/ServerCommands.cpp
+++ b/ServerCommands.cpp
@@ -67,7 +67,7 @@ void CDir::execute()
 		if ((result = dir.read(entries, EDirSortNameAscending)) == KErrNone)
 		{
 			char *payload;
-			size_t offset = 0;
+			size_t nameLength, offset = 0;
 			uint32_t payloadSize = 1;
 
 			/* Iterate through the list of files and determine the amount of memory required to store the filenames */
@@ -81,15 +81,19 @@ void CDir::execute()
 			}
 
 			/* Allocate a buffer large enough to hold the response payload and fill it with the file information */
+			printf("payloadSize = %u\n", payloadSize);
 			payload = new char[payloadSize];
 
 			entry = entries->getHead();
 
 			while (entry != nullptr)
 			{
-				memcpy(payload + offset, entry->iName, strlen(entry->iName) + 1);
-				offset += strlen(entry->iName) + 1;
-				WRITE_INT((payload + offset), entry->iSize);
+				nameLength = strlen(entry->iName);
+				printf("Adding %s of length %lld\n", entry->iName, entry->iSize);
+				printf("Adding %s of length %u %x\n", entry->iName, (uint32_t) entry->iSize, (uint32_t) entry->iSize);
+				memcpy(payload + offset, entry->iName, nameLength + 1);
+				offset += nameLength + 1;
+				WRITE_INT_64((payload + offset), entry->iSize);
 				offset += sizeof(entry->iSize);
 
 				entry = entries->getSucc(entry);


### PR DESCRIPTION
RDir now correctly handles 64 bit file sizes, so we have to handle them in RADRunner as well.