### PR TITLE
Move -mcrt=clib2 to correct variable

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,7 +33,7 @@ ifdef PREFIX
 		LFLAGS += -athread=native
 		OBJ := $(OBJ)_OS4
 	else
-		IFLAGS += -mcrt=clib2
+		CFLAGS += -mcrt=clib2
 		LFLAGS += -mcrt=clib2
 		LIBS += -lnet
 	endif


### PR DESCRIPTION
This should be specified in CFLAGS, not IFLAGS.