### PR TITLE
Change exception that is caught

### DIFF
--- a/RADRunner.cpp
+++ b/RADRunner.cpp
@@ -302,7 +302,7 @@ static TResult StartClient(unsigned short a_port)
 					}
 				}
 			}
-			catch (RSocket::Error &a_exception)
+			catch (std::runtime_error &a_exception)
 			{
 				Utils::Error(a_exception.what());
 			}


### PR DESCRIPTION
The wrong exception type was being caught in the main client, meaning that if an invalid server was detected, the C++ runtime would crash due to an unhandled exception.