### PR TITLE
Add port to host name

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,15 @@ And to use that from a remote computer:
 d:\Source> RADRunner vampire PORT 68000 DIR RAM:
 ```
 
+Note that when connecting to a remote computer, the port can also be specified as a part of the server name or IP
+address.  For instance:
+
+```shell
+d:\Source> RADRunner vampire:68000 DIR RAM:
+```
+
+In this case, the port specified as a part of the server name overrides the port specified with the PORT command.
+
 ### SCRIPT/K \<filename\>
 
 Executes a number of commands inside the RADRunner script file specified by \<filename\>.  See the section "Script Support"

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -1,12 +1,23 @@
 
-Regarding the release status of RADRunner, it is currently in beta.  New releases
-that are built by GitHub may or may not contain improvements, as the builds are
-triggered automatically by code merges, so sometimes a build contains only internal
-non functional changes.
+This ReleaseNotes.txt was added by the author on request from a user.  Until now, the author wasn't aware that the
+application actually had any users!
 
-If a build does contain a new feature or bugfix, I'll try to remember to add it to
-this file with the build's release date.
+Please note that RADRunner is currently in beta. Until version 1.0, binary compatibility between releases is not
+guaranteed.  When a new build has a binary break, it will be mentioned here.  Once version 1.0 is released, it will
+contain a mechanism for detecting incompatible client and server versions.
+
+New releases that are built by GitHub may or may not contain improvements, as the builds are triggered automatically
+by code merges, so sometimes a build contains only internal non functional changes.
+
+If a build does contain a new feature or bugfix, I'll try to remember to add it to this file with the build's release
+date.
 
 Have fun with the Amiga!
 
 Colin Ward AKA Hitman/Code HQ
+
+Version 0.01 (2024.04.24):
+
+  - First public release
+
+  - Added ability to specify the server port as a part of the remote host name, for example localhost:8080


### PR DESCRIPTION
The address of the server can now be specified as host_name:port. This is a more standard way of specifying the port than using a separate PORT argument (although this can still be used).