### PR TITLE
Add stack size to the "execute" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ like this:
 
 ```shell
 $ RADRunner ?
-DIR/K,EXECUTE/K,GET/K,PORT/K,SCRIPT/K,SEND/K,SERVER/S,SHUTDOWN/S,REMOTE
+DIR/K,EXECUTE/K,GET/K,PORT/K,SCRIPT/K,SEND/K,SERVER/S,SHUTDOWN/S,STACKSIZE/K,REMOTE
 ```
 
 Arguments are not case sensitive but by convention on Amiga OS they are typed in upper case, at least in examples.  But
@@ -260,7 +260,7 @@ on the original file.  Protection bits such as the script bit (on Amiga OS) are 
 
 ### PORT/K \<port\>
 
-This command is meant to be used in conjunction with other commands, to direct RADRunner to use a different port to the
+This argument is meant to be used in conjunction with other commands, to direct RADRunner to use a different port to the
 default, which is port 80.  This is useful when that port is being used for something else or is blocked.
 
 For example, to start a server on port 68000 (every Amiga user's favourite number):
@@ -319,6 +319,13 @@ Starts RADRunner in server mode, causing it to listen to incoming connections fr
 ### SHUTDOWN
 
 Shuts down the remote instance of RADRunner, when it's 3 am and time to go to bed.
+
+### STACKSIZE
+
+This argument applies only to Amiga OS, where the stack size has to be manually managed by the user.  By default, a
+stack size of 20k (20,480 bytes) is used when launching programs on Amiga OS using the "execute" command.  Larger stack
+sizes can be specified with this argument.  Values smaller than 4096 are rejected and values larger than INT_MAX
+(2,147,483,647) will be rounded to INT_MAX.
 
 ## More advanced uses
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -16,6 +16,15 @@ Have fun with the Amiga!
 
 Colin Ward AKA Hitman/Code HQ
 
+Version 0.02 (2025.02.07):
+
+  - Bug fix: The Amiga OS version of the "execute" command was launching executables with the default system stack size
+    of 4096 bytes, causing instability.  A default stack size of 20k is now used, and a custom stack size can be
+    specified by the client.  See the documentation for further details.
+
+  - Bumped protocol version to v0.2, as this is a breaking change.  All clients must be updated, as this version is not
+    compabible with protocol v0.1.
+
 Version 0.01 (2024.04.24):
 
   - First public release

--- a/ServerCommands.cpp
+++ b/ServerCommands.cpp
@@ -51,7 +51,7 @@ void CDir::execute()
 {
 	readPayload();
 
-	/* Extract the filename from the payload */
+	/* Extract the directory name from the payload */
 	m_directoryName = reinterpret_cast<char *>(m_payload);
 
 	printf("dir: Listing contents of directory \"%s\"\n", m_directoryName);
@@ -136,9 +136,13 @@ void CExecute::execute()
 {
 	readPayload();
 
-	printf("execute: Executing command \"%s\"\n", m_payload);
+	/* Extract information about the file to be executed from the payload */
+	SExecuteInfo *executeInfo = reinterpret_cast<SExecuteInfo *>(m_payload);
+	SWAP(&executeInfo->m_stackSize);
 
-	TResult result = launchCommand(reinterpret_cast<char*>(m_payload));
+	printf("execute: Executing command \"%s\"\n", executeInfo->m_fileName);
+
+	TResult result = launchCommand(executeInfo->m_fileName, executeInfo->m_stackSize);
 
 	TResponse response{ result.m_result, result.m_subResult };
 	SWAP(&response.m_result);


### PR DESCRIPTION
Amiga OS versions of RADRunner were found to be using the system stack size of 4k by default, rather than inheriting the stack value from the parent process. A larger stack size is now hard coded into RADRunner, and functionality was also added to the Yggdrasil protocol to enable clients to specify a desired stack size as well.