### PR TITLE
Improve client error implementation

### DIFF
--- a/ClientCommands.cpp
+++ b/ClientCommands.cpp
@@ -81,7 +81,6 @@ TResult CExecute::sendRequest()
 	std::string buffer;
 
 	printf("execute: Executing command \"%s\"\n", m_fileName);
-	printf("execute: Requesting execution of \"%s\" with stack size %d\n", m_fileName, m_stackSize);
 
 	/* Include the size of just the filename in the payload size */
 	int32_t payloadSize = static_cast<int32_t>(sizeof(SExecuteInfo) + strlen(m_fileName) + 1);

--- a/RADRunner.cpp
+++ b/RADRunner.cpp
@@ -41,13 +41,13 @@ static const struct Resident g_ROMTag __attribute__((used)) =
 	NT_LIBRARY,
 	0,
 	"RADRunner",
-	"\0$VER: RADRunner 0.02 (10.02.2025)\r\n",
+	"\0$VER: RADRunner 0.03 (17.05.2025)\r\n",
 	NULL
 };
 
 #elif defined(__amigaos__)
 
-static const char g_accVersion[] = "$VER: RADRunner 0.02 (10.02.2025)";
+static const char g_accVersion[] = "$VER: RADRunner 0.03 (17.05.2025)";
 
 #endif /* __amigaos__ */
 

--- a/ReleaseNotes.txt
+++ b/ReleaseNotes.txt
@@ -16,7 +16,12 @@ Have fun with the Amiga!
 
 Colin Ward AKA Hitman/Code HQ
 
-Version 0.02 (2025.02.07):
+Version 0.03 (2025.05.17):
+
+  - Bug Fix: The Amiga OS version of the "execute" command was crashing on OS4. Many thanks to Colin Wenzel of the OS4
+    development team for his help in resolving this issue!
+
+Version 0.02 (2025.02.10):
 
   - Bug fix: The Amiga OS version of the "execute" command was launching executables with the default system stack size
     of 4096 bytes, causing instability.  A default stack size of 20k is now used, and a custom stack size can be

--- a/ServerCommands.cpp
+++ b/ServerCommands.cpp
@@ -161,7 +161,7 @@ void CExecute::execute()
 	}
 	else if (result.m_subResult != 0)
 	{
-		printf("execute: Command \"%s\" was launched successfully but returned failure (Error = %d)\n", m_payload,
+		printf("execute: Command \"%s\" was launched successfully but returned failure (Error = %d)\n", executeInfo->m_fileName,
 			result.m_subResult);
 	}
 }


### PR DESCRIPTION
It turns out that the client error implementation that uses CreateNewProc() crashes on OS4. This commit switches back to using the old way of launching the command, but uses a different mechanism for determining the command's return code.